### PR TITLE
Fixed compilation error in Rocky8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MODULE_big=nanmedian
 OBJS=nanmedian.o
 DATA_built=nanmedian.sql
-DOCS=README.nanmedian
+DOCS=README
 
 OPT=-O3
 OPT_LOW=-O2

--- a/nanmedian.c
+++ b/nanmedian.c
@@ -145,7 +145,7 @@ Datum pgnanmedian_f8(PG_FUNCTION_ARGS)
 	{
 		if (nullsp[i]) { continue; }
 		tmp = DatumGetFloat8(elemsp[i]);
-		if isnan(tmp) { continue;}
+		if (isnan(tmp)) { continue;}
 		procarr[j++] = tmp;
 	}
 	nc = j;
@@ -185,7 +185,7 @@ Datum pgnanmedian_f4(PG_FUNCTION_ARGS)
 	{
 		if (nullsp[i]) { continue; }
 		tmp = DatumGetFloat4(elemsp[i]);
-		if isnan(tmp) { continue;}
+		if (isnan(tmp)) { continue;}
 		procarr[j++] = tmp;
 	}
 	nc = j;
@@ -225,7 +225,7 @@ Datum pgnanmad_f8(PG_FUNCTION_ARGS)
 	{
 		if (nullsp[i]) { continue; }
 		tmp = DatumGetFloat8(elemsp[i]);
-		if isnan(tmp) { continue;}
+		if (isnan(tmp)) { continue;}
 		procarr[j++] = tmp;
 	}
 	nc = j;
@@ -271,7 +271,7 @@ Datum pgnanmad_f4(PG_FUNCTION_ARGS)
 	{
 		if (nullsp[i]) { continue; }
 		tmp = DatumGetFloat4(elemsp[i]);
-		if isnan(tmp) { continue;}
+		if (isnan(tmp)) { continue;}
 		procarr[j++] = tmp;
 	}
 	nc = j;


### PR DESCRIPTION
This extension is old and perhaps unnecessary at this point - maybe the functionality exists in Q3C or healpix already. I'm not an astronomer or a C programmer. But I ran into [this error](https://stackoverflow.com/questions/41111566/c-if-statement-parentheses-with-isnan-macro) building this extension on Rocky8. Tested that it now builds on Rocky8 and still builds on Centos7.